### PR TITLE
unlock iron sticks

### DIFF
--- a/prototypes/ammo/constructors.lua
+++ b/prototypes/ammo/constructors.lua
@@ -257,3 +257,4 @@ data:extend {
 
 local effects = data.raw.technology['nanobots'].effects
 effects[#effects + 1] = {type = 'unlock-recipe', recipe = 'ammo-nano-constructors'}
+effects[#effects + 1] = {type = 'unlock-recipe', recipe = 'iron-stick'}


### PR DESCRIPTION
Added the fix mentioned by Tapio in https://mods.factorio.com/mod/Nanobots2/discussion/6722befcd153c492b15f878a 

The space expansion/2.0 locks iron sticks behind advanced technology, making this 'early game' mod only useable when enough of the tech tree is unlocked that full bots are available.

This change unlocks iron sticks so that nanobot ammo can be crafted early-game.