### PR TITLE
Fix broken spillage and item requests (e.g. beacons) on Nanobots

### DIFF
--- a/scripts/nanobots.lua
+++ b/scripts/nanobots.lua
@@ -180,7 +180,7 @@ local function insert_or_spill_items(entity, item_stacks, is_return_cheat)
             if prototypes.item[name] and not prototypes.item[name].hidden then
                 local inserted = entity.insert({ name = name, count = count, health = health })
                 if inserted ~= count then
-                    entity.surface.spill_item_stack(entity.position, { name = name, count = count - inserted, health = health }, true)
+                    entity.surface.spill_item_stack({position=entity.position, stack={ name = name, count = count - inserted, health = health }, enable_looted=true})
                 end
             end
         end


### PR DESCRIPTION
Encountered this while playing, it deleted an Epic stone brick :(

This commit Fixes that problem by moving to the new spill_item_stack api

See:
[Old](https://lua-api.factorio.com/1.1.110/classes/LuaSurface.html#spill_item_stack) [New](https://lua-api.factorio.com/latest/classes/LuaSurface.html#spill_item_stack)



This also fixes a much bigger issue, item requests, which no longer work via item_requests, instead you have to use the `insert_plan` which is pain...